### PR TITLE
Moved hardcoded AWS bucket name to environmental variable

### DIFF
--- a/move_out/settings.py
+++ b/move_out/settings.py
@@ -95,7 +95,7 @@ AWS_HEADERS = {  # see http://developer.yahoo.com/performance/rules.html#expires
     'Cache-Control': 'max-age=94608000',
 }
 
-AWS_STORAGE_BUCKET_NAME = 'asendecka-moveout-s3'
+AWS_STORAGE_BUCKET_NAME = os.environ.get('AWS_STORAGE_BUCKET_NAME')
 AWS_ACCESS_KEY_ID = os.environ.get('AWS_ACCESS_KEY_ID')
 AWS_SECRET_ACCESS_KEY = os.environ.get('AWS_SECRET_ACCESS_KEY')
 


### PR DESCRIPTION
Hi hi! I changed your harcoded AWS bucket name to variable, so everyone can use their own bucket :) Remember to setup the variable if you decide to merge this! :)
